### PR TITLE
lock boto3 and awscli to pre-urllib3 unification

### DIFF
--- a/salt-minion/Dockerfile
+++ b/salt-minion/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && \
     python-dev \
     python-m2crypto \
     docker-ce=17.12.1~ce-0~ubuntu && \
-    pip install boto boto3 docker awscli && \
+    pip install boto "boto3<1.8.0" docker "awscli<1.16.0" && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
botocore released https://github.com/boto/botocore/pull/1495 3 days ago - since then, our `salt-minion` image has had failures due to an invalid version of requests being used. This locks us to a version before that merge, for now.