### PR TITLE
install kubernetes client via pip

### DIFF
--- a/salt-minion/Dockerfile
+++ b/salt-minion/Dockerfile
@@ -32,15 +32,18 @@ RUN apt-get update && \
     python-dev \
     python-m2crypto \
     docker-ce=17.12.1~ce-0~ubuntu && \
-    pip install boto boto3 docker awscli && \
+    pip install \
+        "pyasn1==0.4.1" \
+        kubernetes \
+        boto \
+        boto3 \
+        docker \
+        awscli && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 # COPY ./state.py /usr/lib/python2.7/dist-packages/salt/modules/
 
-RUN git clone --recursive https://github.com/kubernetes-client/python.git
-RUN pip install pyasn1==0.4.1
-RUN cd python && python setup.py install
 RUN wget https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip && unzip terraform_0.11.7_linux_amd64.zip && \
     mv terraform /usr/local/sbin/
 


### PR DESCRIPTION
This sidesteps the issue #4 works around by installing `kubernetes` via pip before the remaining python dependencies.